### PR TITLE
Adding binding parameter to host call binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ func main() {
 }
 
 func hello(payload []byte) ([]byte, error) {
-	wapc.HostCall("sample", "hello", []byte("Simon"))
+	wapc.HostCall("myBinding", "sample", "hello", []byte("Simon"))
 	return []byte("Hello"), nil
 }
 ```

--- a/example/hello.go
+++ b/example/hello.go
@@ -11,6 +11,6 @@ func main() {
 }
 
 func hello(payload []byte) ([]byte, error) {
-	wapc.HostCall("sample", "hello", []byte("Simon"))
+	wapc.HostCall("myBinding", "sample", "hello", []byte("Simon"))
 	return []byte("Hello"), nil
 }

--- a/wapc.go
+++ b/wapc.go
@@ -20,6 +20,7 @@ func guestError(ptr uintptr, len uint32)
 //go:wasm-module wapc
 //go:export __host_call
 func hostCall(
+	bindingPtr uintptr, bindingLen uint32,
 	namespacePtr uintptr, namespaceLen uint32,
 	operationPtr uintptr, operationLen uint32,
 	payloadPtr uintptr, payloadLen uint32) bool
@@ -94,8 +95,9 @@ func guestCall(operationSize uint32, payloadSize uint32) bool {
 // HostCall invokes an operation on the host.  The host uses `namespace` and `operation`
 // to route to the `payload` to the appropriate operation.  The host will return
 // a response payload if successful.
-func HostCall(namespace, operation string, payload []byte) ([]byte, error) {
+func HostCall(binding, namespace, operation string, payload []byte) ([]byte, error) {
 	result := hostCall(
+		stringToPointer(binding), uint32(len(binding)),
 		stringToPointer(namespace), uint32(len(namespace)),
 		stringToPointer(operation), uint32(len(operation)),
 		bytesToPointer(payload), uint32(len(payload)),


### PR DESCRIPTION
Adding a `binding` parameter to `__host_call` to allow the Host to route the call between potentially multiple components that serve the same namespace.