### PR TITLE
ci: fixes broken build

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -15,11 +15,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # To simplify setup, we use one Go version, even if it is out of the official version range.
+      # This version must be <= max version of earliest TinyGo supported and >= min version of latest.
       matrix:
         go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
-          - "1.16"  # Minimum Go version of latest TinyGo
-          - "1.18"  # Latest
-        tinygo-version:  # See https://github.com/tinygo-org/tinygo/releases
+          - "1.16"  # Minimum Go version of latest TinyGo albeit EOL.
+        tinygo-version:  # Note: TinyGo only supports latest: https://github.com/tinygo-org/tinygo/releases
           - "0.18.0"  # First version to use wasi_snapshot_preview1
           - "0.25.0"  # Latest
 
@@ -27,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.go-version }}
 
       - name: Install TinyGo
         run: |  # Installing via curl so commands are similar on OS/x
@@ -43,7 +44,7 @@ jobs:
         run: tinygo build -o example/hello.wasm -scheduler=none --no-debug -target=wasi example/hello.go
 
       - name: Build test wasm
-        run: cd internal; make build-wasm
+        run: cd internal/e2e; make
 
       - name: Test
         run: go test -v ./...

--- a/example/hello.go
+++ b/example/hello.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	wapc "github.com/wapc/wapc-guest-tinygo"
-)
+import "github.com/wapc/wapc-guest-tinygo"
 
 func main() {
 	wapc.RegisterFunctions(wapc.Functions{

--- a/internal/Makefile
+++ b/internal/Makefile
@@ -1,9 +1,0 @@
-tinygo_sources := $(wildcard testdata/*/*.go)
-.PHONY: build.wasm
-build-wasm: $(tinygo_sources)
-	@echo "------------------"
-	@echo "Building Test Wasm"
-	@echo "------------------"
-	@for f in $^; do \
-	    tinygo build -o $$(echo $$f | sed -e 's/\.go/\.wasm/') -scheduler=none --no-debug -target=wasi $$f; \
-	done

--- a/internal/e2e/Makefile
+++ b/internal/e2e/Makefile
@@ -1,0 +1,6 @@
+tinygo_sources := $(wildcard */*.go)
+build: $(tinygo_sources)
+	@echo "Building End-to-End Wasm"
+	@for f in $^; do \
+	    tinygo build -o $$(echo $$f | sed -e 's/\.go/\.wasm/') -scheduler=none --no-debug -target=wasi $$f; \
+	done

--- a/internal/e2e/README.md
+++ b/internal/e2e/README.md
@@ -1,0 +1,6 @@
+## waPC Guest Library for TinyGo End-to-End Tests
+
+This is an internal project holding source for various test guest wasm used to
+cover corner cases. This has its own [go.mod](go.mod) and [Makefile](Makefile)
+as the guest source is compiled with TinyGo, not Go. The `%.wasm` binaries here
+are checked in, to ensure end-to-end tests run without any prerequisite setup.

--- a/internal/e2e/__console_log/main.go
+++ b/internal/e2e/__console_log/main.go
@@ -1,5 +1,7 @@
 package main
 
+import "github.com/wapc/wapc-guest-tinygo"
+
 func main() {
 	wapc.ConsoleLog("msg")
 	wapc.ConsoleLog("msg1")

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,0 +1,8 @@
+module github.com/wapc/wapc-guest-tinygo/internal/e2e
+
+// Match min version in go-test.yaml
+go 1.16
+
+require github.com/wapc/wapc-guest-tinygo v0.0.0
+
+replace github.com/wapc/wapc-guest-tinygo => ../../


### PR DESCRIPTION
e2e tests need  a different go.mod than what generates their wasm