### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -13,7 +13,8 @@ func hostCall(
 	bindingPtr uintptr, bindingLen uint32,
 	namespacePtr uintptr, namespaceLen uint32,
 	operationPtr uintptr, operationLen uint32,
-	payloadPtr uintptr, payloadLen uint32) bool {
+	payloadPtr uintptr, payloadLen uint32,
+) bool {
 	return true
 }
 

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0
-	github.com/tetratelabs/wazero v1.0.0-pre.2
+	github.com/tetratelabs/wazero v1.0.0-pre.4
 )
 
 require (

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -8,8 +8,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/host_test.go
+++ b/internal/host_test.go
@@ -12,25 +12,41 @@ import (
 func instantiateWapcHost(t *testing.T, r wazero.Runtime) (*wapcHost, api.Closer) {
 	h := &wapcHost{t: t}
 	// Export host functions (in the order defined in https://wapc.io/docs/spec/#required-host-exports)
-	if host, err := r.NewModuleBuilder("wapc").
-		ExportFunction("__host_call", h.hostCall,
-			"__host_call", "bind_ptr", "bind_len", "ns_ptr", "ns_len", "cmd_ptr", "cmd_len", "payload_ptr", "payload_len").
-		ExportFunction("__console_log", h.consoleLog,
-			"__console_log", "ptr", "len").
-		ExportFunction("__guest_request", h.guestRequest,
-			"__guest_request", "op_ptr", "ptr").
-		ExportFunction("__host_response", h.hostResponse,
-			"__host_response", "ptr").
-		ExportFunction("__host_response_len", h.hostResponseLen,
-			"__host_response_len").
-		ExportFunction("__guest_response", h.guestResponse,
-			"__guest_response", "ptr", "len").
-		ExportFunction("__guest_error", h.guestError,
-			"__guest_error", "ptr", "len").
-		ExportFunction("__host_error", h.hostError,
-			"__host_error", "ptr").
-		ExportFunction("__host_error_len", h.hostErrorLen,
-			"__host_error_len").
+	if host, err := r.NewHostModuleBuilder("wapc").
+		NewFunctionBuilder().
+		WithFunc(h.hostCall).
+		WithParameterNames("bind_ptr", "bind_len", "ns_ptr", "ns_len", "cmd_ptr", "cmd_len", "payload_ptr", "payload_len").
+		Export("__host_call").
+		NewFunctionBuilder().
+		WithFunc(h.consoleLog).
+		WithParameterNames("ptr", "len").
+		Export("__console_log").
+		NewFunctionBuilder().
+		WithFunc(h.guestRequest).
+		WithParameterNames("op_ptr", "ptr").
+		Export("__guest_request").
+		NewFunctionBuilder().
+		WithFunc(h.hostResponse).
+		WithParameterNames("ptr").
+		Export("__host_response").
+		NewFunctionBuilder().
+		WithFunc(h.hostResponseLen).
+		Export("__host_response_len").
+		NewFunctionBuilder().
+		WithFunc(h.guestResponse).
+		WithParameterNames("ptr", "len").
+		Export("__guest_response").
+		NewFunctionBuilder().
+		WithFunc(h.guestError).
+		WithParameterNames("ptr", "len").
+		Export("__guest_error").
+		NewFunctionBuilder().
+		WithFunc(h.hostError).
+		WithParameterNames("ptr").
+		Export("__host_error").
+		NewFunctionBuilder().
+		WithFunc(h.hostErrorLen).
+		Export("__host_error_len").
 		Instantiate(testCtx, r); err != nil {
 		t.Errorf("Error instantiating waPC host - %v", err)
 		return h, nil

--- a/wapc.go
+++ b/wapc.go
@@ -18,9 +18,7 @@ type (
 	}
 )
 
-var (
-	allFunctions = Functions{}
-)
+var allFunctions = Functions{}
 
 // RegisterFunctions adds functions by name to the registry.
 // This should be invoked in `main()`.


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API