### PR TITLE
ci: update Go and TinyGo versions for testing 🚀

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -19,10 +19,11 @@ jobs:
       # This version must be <= max version of earliest TinyGo supported and >= min version of latest.
       matrix:
         go-version:  # Note: Go only supports 2 versions: https://go.dev/doc/devel/release#policy
-          - "1.22"
           - "1.23"
+          - "1.24"
         tinygo-version:  # Note: TinyGo only supports latest: https://github.com/tinygo-org/tinygo/releases
-          - "0.35.0"  # Latest
+          - "0.37.0"
+          - "0.38.0"
 
     steps:
       - name: Set up Go


### PR DESCRIPTION
This pull request updates the Go and TinyGo versions in the GitHub Actions workflow configuration file to ensure compatibility with the latest supported versions.

Version updates in `.github/workflows/go-test.yaml`:

* Updated Go versions in the matrix to include `1.24` and removed `1.22`.
* Updated TinyGo versions in the matrix to include `0.37.0` and `0.38.0`, replacing `0.35.0`.